### PR TITLE
Call registerAppInfo on mount

### DIFF
--- a/src/lib/Container.svelte
+++ b/src/lib/Container.svelte
@@ -1,11 +1,12 @@
 <script>
   import { setContext } from 'svelte'
-  import { isServer } from './util'
+  import { isServer, register } from './util'
 
   export let stripe
 
   const elements = isServer ? null : stripe.elements()
 
+  register(stripe)
   setContext('stripe', { stripe, elements })
 </script>
 

--- a/src/lib/PaymentElement.svelte
+++ b/src/lib/PaymentElement.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount, createEventDispatcher } from 'svelte'
-  import { mount, isServer } from './util'
+  import { mount, isServer, register } from './util'
 
   export let stripe
   export let clientSecret
@@ -15,6 +15,7 @@
   const dispatch = createEventDispatcher()
 
   onMount(() => {
+    register(stripe)
     element = mount(wrapper, 'payment', elements, dispatch)
 
     return () => element.unmount()

--- a/src/lib/PaymentRequestButton.svelte
+++ b/src/lib/PaymentRequestButton.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { mount } from './util'
   import { onMount, getContext, createEventDispatcher } from 'svelte'
 
   export let classes = {}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -13,3 +13,12 @@ export function mount(node, type, elements, dispatch, options={}) {
 }
 
 export const isServer = typeof(window) === 'undefined'
+
+export function register(stripe) {
+  if (!isServer) {
+    return stripe.registerAppInfo({
+      name: 'svelte-stripe-js',
+      url: 'https://svelte-stripe-js.vercel.app',
+    })
+  }
+}


### PR DESCRIPTION
Hey, thanks a ton for all your hard work with this library!

Would it be okay to add this line so that our support team can better identify when requests are coming from integrations using your tools? This PR just adds `registerAppInfo`, following [this doc](https://stripe.com/docs/building-plugins)